### PR TITLE
Update `exp` package

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,5 +4,5 @@ go 1.18
 
 require (
 	github.com/fxamacker/circlehash v0.3.0
-	golang.org/x/exp v0.0.0-20221110155412-d0897a79cd37
+	golang.org/x/exp v0.0.0-20240103183307-be819d1f06fc
 )

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,4 @@
 github.com/fxamacker/circlehash v0.3.0 h1:XKdvTtIJV9t7DDUtsf0RIpC1OcxZtPbmgIH7ekx28WA=
 github.com/fxamacker/circlehash v0.3.0/go.mod h1:3aq3OfVvsWtkWMb6A1owjOQFA+TLsD5FgJflnaQwtMM=
-golang.org/x/exp v0.0.0-20221110155412-d0897a79cd37 h1:wKMvZzBFHbOCGvF2OmxR5Fqv/jDlkt7slnPz5ejEU8A=
-golang.org/x/exp v0.0.0-20221110155412-d0897a79cd37/go.mod h1:CxIveKay+FTh1D0yPZemJVgC/95VzuuOLq5Qi4xnoYc=
+golang.org/x/exp v0.0.0-20240103183307-be819d1f06fc h1:ao2WRsKSzW6KuUY9IWPwWahcHCgR0s52IfwutMfEbdM=
+golang.org/x/exp v0.0.0-20240103183307-be819d1f06fc/go.mod h1:iRJReGqOEeBhDZGkGbynYwcHlctCvnjTYIamk7uXpHI=

--- a/mph.go
+++ b/mph.go
@@ -38,8 +38,8 @@ func Build(keys []string) *Table {
 			buckets = append(buckets, indexBucket{n, vals})
 		}
 	}
-	slices.SortFunc(buckets, func(a, b indexBucket) bool {
-		return len(a.vals) > len(b.vals)
+	slices.SortFunc(buckets, func(a, b indexBucket) int {
+		return len(a.vals) - len(b.vals)
 	})
 
 	occ := make([]bool, len(level1))


### PR DESCRIPTION
Update `golang.org/x/exp` version and fix a breaking change.

The breaking change causes a build issue when the package is imported in a project where `golang.org/x/exp` is also imported with a newer version. 